### PR TITLE
Add Webpack configuration for Expo

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,10 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    plugins: [
+      '@babel/plugin-transform-runtime',
+      '@babel/plugin-proposal-class-properties',
+      '@babel/plugin-proposal-object-rest-spread'
+    ]
   };
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "build": "webpack --mode production"
   },
   "dependencies": {
     "@aws-amplify/react-native": "^1.1.6",
@@ -49,7 +50,13 @@
     "react-native-svg": "^15.8.0",
     "react-native-url-polyfill": "^2.0.0",
     "react-native-web": "~0.19.10",
-    "react-remove-scroll-bar": "^2.3.6"
+    "react-remove-scroll-bar": "^2.3.6",
+    "webpack": "^5.64.4",
+    "webpack-cli": "^4.9.1",
+    "babel-loader": "^8.2.3",
+    "style-loader": "^3.3.1",
+    "css-loader": "^6.5.1",
+    "html-webpack-plugin": "^5.5.0"
   },
   "devDependencies": {
     "@aws-amplify/backend": "^1.5.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,43 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  mode: 'development',
+  entry: './index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+  },
+  resolve: {
+    extensions: ['.js', '.jsx', '.ts', '.tsx'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx|ts|tsx)$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+        },
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader'],
+      },
+      {
+        test: /\.(png|svg|jpg|jpeg|gif)$/i,
+        type: 'asset/resource',
+      },
+    ],
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: './public/index.html',
+    }),
+  ],
+  devServer: {
+    contentBase: path.join(__dirname, 'dist'),
+    compress: true,
+    port: 9000,
+  },
+};


### PR DESCRIPTION
Add Webpack configuration for Expo and update project files for Webpack compatibility.

* **webpack.config.js**: Add Webpack configuration with necessary loaders and plugins, set entry point to `index.js`.
* **package.json**: Add Webpack as a dependency, add a script for Webpack build.
* **babel.config.js**: Add necessary plugins for Webpack compatibility.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/khaled-rashwan/digital_art_house/pull/1?shareId=5c023cdb-afd6-4fd1-9983-38886d1d758e).