### PR TITLE
Fix Babel configuration for loose mode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "tasks": {
+    "test": "echo \"No test script found in package.json\"",
+    "build": "npm install && npm run build",
+    "launch": "npm start"
+  }
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,9 @@ module.exports = function(api) {
     presets: ['babel-preset-expo'],
     plugins: [
       '@babel/plugin-transform-runtime',
-      '@babel/plugin-proposal-class-properties',
+      ['@babel/plugin-proposal-class-properties', { loose: true }], // Pf91d
+      ['@babel/plugin-proposal-private-methods', { loose: true }], // P33b0
+      ['@babel/plugin-proposal-private-property-in-object', { loose: true }], // P2fb7
       '@babel/plugin-proposal-object-rest-spread'
     ]
   };


### PR DESCRIPTION
Add `loose` option to Babel plugins to fix build error.

* **babel.config.js**
  - Add `loose` option to `@babel/plugin-proposal-class-properties`
  - Add `loose` option to `@babel/plugin-proposal-private-methods`
  - Add `loose` option to `@babel/plugin-proposal-private-property-in-object`

* **.devcontainer/devcontainer.json**
  - Add tasks for `test`, `build`, and `launch` commands

